### PR TITLE
improved debugging in browser console

### DIFF
--- a/scripts/systems/ai.js
+++ b/scripts/systems/ai.js
@@ -15,7 +15,7 @@ elation.require("engine.things.controller", function() {
           try {
             this.performThink(this.thinkers[i], ev.data);
           } catch (e) {
-            console.log(e.stack);
+            console.log(e);
           }
         }
       }

--- a/scripts/systems/world.js
+++ b/scripts/systems/world.js
@@ -406,7 +406,7 @@ elation.require([
           //console.log(logprefix + "\t- added new " + type + ": " + name, currentobj);
         }
       } catch (e) {
-        console.error(e.stack);
+        console.error(e);
       }
       return currentobj;
     }


### PR DESCRIPTION
These fixes will improve (textonly) errormsgs in the janusweb browserconsole:

```
this.getObjectByDeepName@http://localhost:8080/build/1.5.56/janusweb.js:143362:17
this.getSpawnpoint@http://localhost:8080/build/1.5.56/janusweb.js:141696:60
this.setHash@http://localhost:8080/build/1.5.56/
```

to a line-by-line clickable/navigate-able one, preceded by the actual error message:

```javascript
TypeError: can't access property "objects", this.janus.currentroom is undefined
    getObjectByDeepName http://localhost:8080/build/1.5.56/janusweb.js:143362
    getSpawnpoint http://localhost:8080/build/1.5.56/janusweb.js:141696
    setHash http://localhost:8080/build/1.5.56/janusweb.js:141659
```

Not sure if `e.stack` was done on purpose because of security reasons, but this makes it much easier to troubleshoot while developing.
Worstcase we can make the `util/build.sh`-script (of janusweb) support an environment-flag `PRODUCTION`.
Then in `util/build.sh` we could do things like `test -n "$PRODUCTION" && grep -r -l 'console\.' elation | xargs -n1 sed -s 's|console\..*||g'` to remove all console-calls before uglify-js starts.


> ps. just want to say I think the elation-engine is rare well-designed fast-performant XR framework. Not sure how old it is, but till this day most (THREE/AFRAME) XR projects are just one-scene-creations. I suggest changing the github description from `Elation Javascript Game Engine` to `Elation Javascript Game Browser Engine #three #webxr` (that would have allowed me to find it easier) as most js game engines focus on 2D, 3D but not WebXR.
