### PR TITLE
renderbug: allow events without element

### DIFF
--- a/scripts/systems/render.js
+++ b/scripts/systems/render.js
@@ -1387,7 +1387,7 @@ console.log('toggle render mode: ' + this.rendermode + ' => ' + mode, passidx, l
           }
         }
 
-        if (bubble) {
+        if (bubble && element) {
           //console.log('bubble it!', event, element);
           var ptr = element;
           while (ptr = ptr.parent) {


### PR DESCRIPTION
The event system allows for generic events (like firing something without an element-value e.g.).
This is great, because that allows assetscripts to fire stuff without passing an element.
But...render.js chokes on it (sometimes every frame when listening to frame events).
This fix prevents hogging the console with errors (of not being able to read `.parent` from `null`)

> I have a hunch that due to the lazy initializations of elements in janusweb, `element` sometimes **also** might be null for small amounts of time. I'm saying this because I'm stresstesting loading 5 nested heavy janus-rooms simultaniously (vesta + janusxr lobby +  etc ) via `<link url="..." url_pos="0 0 0" auto_load="true" />`, so this might be a good discover :heart_eyes: 