### PR TITLE
render: harden findFillSize so a fullsize view can't collapse to a sliver on resize

### DIFF
--- a/scripts/systems/render.js
+++ b/scripts/systems/render.js
@@ -1133,13 +1133,20 @@ console.log('toggle render mode: ' + this.rendermode + ' => ' + mode, passidx, l
       else this.removeclass('state_pointerlock_lost');
     }
     findFillSize() {
-      // fullsize means "fill whatever area we're given": climb toward the root and use
-      // the first ancestor that has a laid-out height, so we measure the actual
-      // containing block. Fall back to the window only if nothing in the chain has a
-      // non-zero height (e.g. before layout, or an unconstrained document).
-      var node = this;
-      while (node) {
-        if (node.offsetHeight > 0) return {w: node.offsetWidth, h: node.offsetHeight};
+      // fullsize means "fill whatever area we're given". The view element is
+      // deliberately collapsed in fullsize mode (the canvas is position:absolute, out
+      // of flow), so measure its CONTAINER, not itself -- start the climb at the
+      // parent. Use the nearest ancestor that establishes a real, laid-out height.
+      // A content-collapsed chain (an unconstrained page whose html/body/container
+      // have no established height -- only a few px of in-flow chrome) reports a
+      // sliver far below any usable viewer; in that case fill the window, which is
+      // what a fullsize view wants. The old code started at `this` and accepted the
+      // first offsetHeight > 0, so a few-px collapse short-circuited the window
+      // fallback and sized the canvas to a sliver on resize.
+      var MIN_REAL_H = 64;   // px: below this a container is treated as collapsed, not a real box
+      var node = this.parentElement;
+      while (node && node !== document.documentElement) {
+        if (node.offsetHeight >= MIN_REAL_H) return {w: node.offsetWidth, h: node.offsetHeight};
         node = node.parentElement;
       }
       return {w: window.innerWidth, h: window.innerHeight};


### PR DESCRIPTION
## Problem
Resizing the browser collapses a `fullsize` render view's WebGL canvas to a few pixels **high** (width stays correct).

## Root cause
`6f222a1` redefined a `fullsize` view to measure its containing block via `findFillSize()` and took the canvas out of flow (`position:absolute`, view element gets no height); `ada834b` re-runs the measurement on every resize via a `ResizeObserver`. `findFillSize()` started the climb at the (now deliberately collapsed) view element and returned the **first ancestor with `offsetHeight > 0`**, only falling back to the window if the *entire* chain was exactly `0`. On an unconstrained page (no established height on `html`/`body`/container — e.g. a bare `<janus-viewer>`, which defaults `fullsize:true`), the chain collapses to a few px of in-flow chrome, `findFillSize` locks onto that sliver, and `setrendersize()` sizes the buffer to a few pixels tall on every resize.

## Fix
`findFillSize()` now:
1. Starts the climb at `this.parentElement` — the view collapses by design in fullsize mode, so measuring it is always wrong here.
2. Falls back to `window.innerWidth/innerHeight` when no ancestor establishes a **real** height (`>= 64px`), instead of only when the whole chain is exactly `0`. A real sized/docked container (`>= 64px`) is still honored, preserving `6f222a1`'s "size to container" intent.

Verified against mock DOM chains: collapsed chain → window; `height:100%` body → window; a real 400px container → the container; a chrome sliver below a sized container → climbs past the sliver to the container.